### PR TITLE
Call generate hash script with JAVA_HOME

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -2,11 +2,12 @@
 - name: Generate hash for users opendistro
   shell: |
     bash {{ opendistro_plugin_dir }}/opendistro_security/tools/hash.sh -p {{ item.pass }}
-    tail -n 1
   no_log: true
   register: opendistro_hash
   loop: "{{ security_plugin_passwords }}"
   when: not default_security_plugins | bool
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-11/
 
 - name: Set facts
   set_fact:


### PR DESCRIPTION
With JAVA_HOME variable, tail command is not required.